### PR TITLE
Corrected Mac requirements info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ You'll need gnupg2 installed. Most Linux distros have some variant of
 
 `apt-get install gnupg`
 
-Mac OS X can do
+Mac OS X users with [homebrew][1] installed can do
 
-`brew install gnupg`
+`brew install gnupg2`
+
+Or else install the full [GPGTools][2] suite.
 
 Whatever package you install will need to include `gpg` and `gpgconf`.
 
@@ -95,3 +97,6 @@ goals outlined in the introduction are inflexible, though.
 Furthermore, be aware that the act of issuing a Pull Request to this repository
 contitutes a contribution of the work in the Pull Request into the public
 domain.
+
+[1]: http://brew.sh/
+[2]: https://gpgtools.org/

--- a/waivers/KenHagler.asc
+++ b/waivers/KenHagler.asc
@@ -1,0 +1,38 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+# Copyright waiver for <https://github.com/nyarly/simplekey>
+
+I dedicate any and all copyright interest in this software to the
+public domain. I make this dedication for the benefit of the public at
+large and to the detriment of my heirs and successors. I intend this
+dedication to be an overt act of relinquishment in perpetuity of all
+present and future rights to this software under copyright law.
+
+To the best of my knowledge and belief, my contributions are either
+originally authored by me or are derived from prior works which I have
+verified are also in the public domain and are not subject to claims
+of copyright by other parties.
+
+To the best of my knowledge and belief, no individual, business,
+organization, government, or other entity has any copyright interest
+in my contributions, and I affirm that I will not make contributions
+that are otherwise encumbered.
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG/MacGPG2 v2.0.22 (Darwin)
+Comment: GPGTools - http://gpgtools.org
+
+iQIcBAEBCgAGBQJTZwrjAAoJED2PXpkfkn2fS9cP+gL2nZYBWq22h2P+0dPUaWr1
+H9EPOV8oFjzXQtL9hnRVuygDnRm0uEl90WpVya9PrpJEcAZMO1eFladJl6iCNFFq
+UevyNmIG5ruY2LgCUEauKgAPv5mSSDvop1+FpjPGSWUXub2Fo0QIGE3vcZiwvLsP
+StCl5GpJTT2qEGY5lHXLDh1LNQCmXRMu9JWJ8vC7K2ikB+sc7N2/ED0sZhU+OFPX
+8HF1VR8wffBRvk1zCDVr+p+AGXc9bQ9gPcDFjIvKbNQaQo7G7bVohrLf8MYuhVgV
+tvRCGcpnxNLlGsVP4kYZgfdt1y7EM+xPpCWgDWVHui6Il4NiDFTVqO9NoPcF0+bT
+akMH/tmG8XI0Mx4GFP678WtnNiT2+3j52dUZh+/qHefuvPLrCIV4rWx3UwdNaRBl
+CaGUqyLno+RAHt8qPAFdCWDLMnjckXuSA1TpautGRMvvJ7idBODtI6eajkBd5t8p
+Ov9Foqnh1aEfhNzDwjeKaRGS9c1lAOMEoWRo1kFUUVbivsNWvk69DNw7DJW6PKu7
+2/HGNj3+pLABNVpx6Jcm/0IFBah+3SLMj5Nax8ePkPRwvr/ZUlnEBH0aNHjHpjoR
+MmQyc0GU1b8y6ClldmYaEVrN7CaVoaxhfO6au789+HNbxsQFtolg3vppwgpGfmEJ
+oSP9npaJPDDG5or6/hI+
+=XNYm
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
The information on installing gnupg2 for Mac OS X was wrong, and also incomplete as Mac users won't necessarily have Homebrew, nor is that the only (or even the best) way to get it on a Mac.
